### PR TITLE
Update publish group-id

### DIFF
--- a/godel/config/dist-plugin.yml
+++ b/godel/config/dist-plugin.yml
@@ -30,4 +30,4 @@ products:
     publish: {}
 product-defaults:
   publish:
-    group-id: com.palantir.godel.distgo-asset-dist-golangci-lint
+    group-id: com.palantir.distgo-asset-dist-golangci-lint


### PR DESCRIPTION


## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Changes the group-id value for the published artifact to "com.palantir.distgo-asset-dist-golangci-lint".

The default OSS godel resolver uses the 2nd element as the GitHub org name and the 3rd element as the GitHub repo name, so this construction is necessary for proper resolution.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

