### PR TITLE
Update publish group-id to com.palantir.godel-distgo-asset-dist-golangci-lint

### DIFF
--- a/godel/config/dist-plugin.yml
+++ b/godel/config/dist-plugin.yml
@@ -30,4 +30,4 @@ products:
     publish: {}
 product-defaults:
   publish:
-    group-id: com.palantir.distgo-asset-dist-golangci-lint
+    group-id: com.palantir.godel-distgo-asset-dist-golangci-lint


### PR DESCRIPTION


## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Updates publish group-id to com.palantir.godel-distgo-asset-dist-golangci-lint.

Makes the third component match the GitHub repository name exactly.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

