### PR TITLE
Update default version of golangci-lint for dist to v2.9.0

### DIFF
--- a/golangcilint/config/config.go
+++ b/golangcilint/config/config.go
@@ -21,7 +21,7 @@ import (
 
 // Default version of golangci-lint to compile for output binary if no version is specified in configuration.
 // Should generally track/match the latest golangci-lint release: https://github.com/golangci/golangci-lint/releases
-const defaultVersion = "v2.4.0"
+const defaultVersion = "v2.9.0"
 
 type GolangCILint v0.Config
 


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Updates the default value for the golangci-lint version to use to build distributions to v2.9.0, which is the version that adds support for Go 1.26.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

